### PR TITLE
#24 fix : modify item list&show api

### DIFF
--- a/lands/services.py
+++ b/lands/services.py
@@ -59,7 +59,7 @@ class ItemImageService:
         image.full_clean()
         image.save()
         
-        return settings.MEDIA_URL+image.image.name
+        return (settings.MEDIA_URL+image.image.name, image.pk)
 
 class ItemService:
     def __init__(self):
@@ -75,8 +75,21 @@ class ItemService:
             return False
         else:
             item.show=True
-            
             item.full_clean()
             item.save()
             return True
+    
+    @staticmethod
+    def create(user,image_id:str,show=bool):
+        item_image=get_object_or_404(ItemImage, pk=image_id)
+        land=get_object_or_404(Land,user=user)
+        item=Item(
+            item_image=item_image,
+            show=show,
+            land=land,
+            user=user,
+        )
+        item.full_clean()
+        item.save()
         
+        return item

--- a/lands/urls.py
+++ b/lands/urls.py
@@ -6,7 +6,8 @@ app_name = "lands"
 urlpatterns=[
     path('create/',LandCreateApi.as_view(),name='create'),
     path('item/img/create/',ItemImageCreateApi.as_view(),name='item_img_create'),
-    path('<int:item_id>/show/',ItemShowUpdateApi.as_view(),name='item_show'),
-    path('<int:user_id>/items/',UserLandItemListApi.as_view(),name='lands_items'),
+    path('show/',ItemShowUpdateApi.as_view(),name='item_show'),
+    path('<int:user_id>/',UserLandItemListApi.as_view(),name='lands_items'),
     path('item/update/',ItemLocationUpdateApi.as_view(),name='item_update'),
+    path('item/create/',ItemCreateApi.as_view(),name='item_create'),
 ]

--- a/lands/views.py
+++ b/lands/views.py
@@ -5,6 +5,10 @@ from rest_framework.views import APIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework import serializers, status
 from rest_framework.response import Response
+import logging
+
+logger = logging.getLogger(__name__)
+from users.models import User
 from .selectors import ItemSelector, LandSelector
 from rest_framework.exceptions import PermissionDenied
 from .models import Land, Location, Item, ItemImage
@@ -46,20 +50,49 @@ class ItemImageCreateApi(APIView):
         serializer.is_valid(raise_exception=True)
         data=serializer.validated_data
         
-        item_img_url=ItemImageService.create(
+        item_img_url,image_pk=ItemImageService.create(
             image=data.get('image'),
         )
         
         return Response({
             'status':'success',
-            'data':{'url':item_img_url},
+            'data':{'img_pk':image_pk,
+                'url':item_img_url},
         },status=status.HTTP_201_CREATED)
+
+class ItemCreateApi(APIView):
+    permission_classes=(AllowAny,)
+    
+    class ItemCreateInputSerializer(serializers.Serializer):
+        image_id = serializers.CharField()
+
+    
+    def post(self,request):
+        serializer=self.ItemCreateInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data=serializer.validated_data
         
-#아이템 show 변경 api
+        item=ItemService.create(
+            image_id=data.get('image_id'),
+            show=False,
+            user=request.user,
+        )
+        
+        return Response({
+            'status':'success',
+            'data':{
+                'item_pk':item.pk,
+                'item_image':item.item_image.image.url,
+                'item_show':item.show,
+            }
+        })
+        
+#아이템 show 변경 api(사용->사용X시)
 class ItemShowUpdateApi(APIView):
     permission_classes=(IsAuthenticated,)
     
-    def post(self, request, item_id):
+    def post(self, request, *args, **kwargs):
+        item_id=request.data.get('item_id')
         item = get_object_or_404(Item, pk=item_id)
         # 현재 로그인한 유저가 해당 아이템의 소유자인지 확인
         if item.user != request.user:
@@ -110,12 +143,33 @@ class UserLandItemListApi(APIView):
         
         def get_items(self, obj):
             return UserLandItemListApi.ItemSerializer(obj.lands.all(), many=True).data
+        
+    class PublicLandItemOutputSerializer(serializers.Serializer):
+        lands = serializers.SerializerMethodField()
+        items = serializers.SerializerMethodField()
 
+        def get_lands(self, obj):
+            s3_base_url = "https://s3.amazonaws.com/cognisle.shop/media/lands/background/"
+            land_img = f'{s3_base_url}land{obj.background}'
+            bg_img = f'{s3_base_url}bg{obj.background}'
+            return {'state': obj.background, 'land_img': land_img, 'bg_img': bg_img}
+
+        def get_items(self, obj):
+            return UserLandItemListApi.ItemSerializer(obj.lands.filter(show=True), many=True).data
+        
     def get(self, request, user_id):
-        if request.user.id != user_id:
-            raise PermissionDenied("You do not have permission to access this user's data.")
+        user = get_object_or_404(User, pk=user_id)
+        print(user.email)
+        print(request.user.id)
+        logger.info(f"Fetching lands and items for user_id: {user_id}")
+
         lands_items = LandSelector.get_lands_and_items(user_id=user_id)
-        output_serializer = self.LandItemOutputSerializer(lands_items, many=True)
+        logger.info(f"Lands and items retrieved: {lands_items}")
+        lands_items = LandSelector.get_lands_and_items(user_id=user_id)
+        if request.user.id == user_id:
+            output_serializer = self.LandItemOutputSerializer(lands_items, many=True)
+        else:
+            output_serializer = self.PublicLandItemOutputSerializer(lands_items, many=True)
         return Response(output_serializer.data, status=status.HTTP_200_OK)
 
 class ItemLocationUpdateApi(APIView):


### PR DESCRIPTION
- item show api 수정 : url에 item pk 값 들어가던거 body로 보내도록 함
- item list api 수정 
  GET method라서 user_id를 url에 유지
  land의 user 와 request의 user를 비교
  - 같으면 : 소유한 아이템 모두 출력하도록 (즉 ,소유했지만 사용하지 않은 아이템 포함)
  - 다르면 : 사용한 아이템만 모두 출력하도록 (소유&사용X인 아이템 X)
 하나의 api 안에서 outputserializer 구분하여 출력
- item create api 생성
  item image 생성했던거 pk 받아서 item이랑 lands랑 연결
