### PR TITLE
#51 fix : modify upload function for custom image path

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -9,7 +9,7 @@ from datetime import datetime
 def get_random_text(length):
     return str(uuid.uuid4()).replace('-', '')[:length]
 
-def s3_file_upload_by_file_data(upload_file, region_name, bucket_name, bucket_path, content_type=None):
+def s3_file_upload_by_file_data(upload_file, region_name, bucket_name, bucket_path,file_name=None,content_type=None):
     bucket_name = bucket_name.replace('/', '')
     # 파일 확장자 추출
     if content_type:
@@ -23,8 +23,11 @@ def s3_file_upload_by_file_data(upload_file, region_name, bucket_name, bucket_pa
 
     #random_file_name = '{}.{}'.format(str(now.strftime('%Y%m%d%H%M%S'))+random_str,extension)
     # 파일의 ContentType을 설정
-    random_file_name = f"{now.strftime('%Y%m%d%H%M%S')}_{random_str}.{extension}"
-    upload_file_path_name = f"{bucket_path}/{random_file_name}"
+    if not file_name:
+        file_name = f"{now.strftime('%Y%m%d%H%M%S')}_{random_str}.{extension}"
+    else:
+        file_name=f"{file_name}.{extension}"
+    upload_file_path_name = f"{bucket_path}/{file_name}"
     print(upload_file_path_name)
     s3 = boto3.resource('s3', region_name=region_name, aws_access_key_id=development.AWS_ACCESS_KEY_ID, aws_secret_access_key=development.AWS_SECERT_ACCESS_KEY)
 

--- a/lands/services.py
+++ b/lands/services.py
@@ -64,7 +64,7 @@ class ItemImageService:
             upload_file=image,
             region_name=development.AWS_S3_REGION_NAME,
             bucket_name=development.AWS_STORAGE_BUCKET_NAME,
-            bucket_path=f'media/item',
+            bucket_path=f'media/items',
             file_name=name,
         )
         item_image=ItemImage(image=img_url)

--- a/lands/services.py
+++ b/lands/services.py
@@ -59,12 +59,13 @@ class ItemImageService:
         pass
     
     @staticmethod
-    def create(image:ImageFile):
+    def create(image:ImageFile,name:str):
         img_url=s3_file_upload_by_file_data(
             upload_file=image,
             region_name=development.AWS_S3_REGION_NAME,
             bucket_name=development.AWS_STORAGE_BUCKET_NAME,
-            bucket_path=f'media/lands/item/pic'
+            bucket_path=f'media/item',
+            file_name=name,
         )
         item_image=ItemImage(image=img_url)
         item_image.save()

--- a/lands/views.py
+++ b/lands/views.py
@@ -73,6 +73,7 @@ class ItemImageCreateApi(APIView):
     
     class ItemImageCreateInputSerializer(serializers.Serializer):
         image=serializers.ImageField()
+        name=serializers.CharField(required=False)
     
     @swagger_auto_schema(
         request_body=ItemImageCreateInputSerializer,
@@ -103,6 +104,7 @@ class ItemImageCreateApi(APIView):
         
         item_img_url,image_pk=ItemImageService.create( 
             image=data.get('image'),
+            name=data.get('name'),
         )
         
         return Response({


### PR DESCRIPTION
- 이미지 경로, 이름 post 할 때 커스텀 할 수 있도록 name 필드 추가
- item image create api에서 기본 주소는 버킷주소/media/items 이고 그 뒤는 원하는대로 입력 가능
- ex) game 에 사용하는 카드 이미지 업로드한 case
![image](https://github.com/user-attachments/assets/e1135862-988e-4e2e-9d74-587de381f825)
